### PR TITLE
make assign-role use get-member

### DIFF
--- a/lib/API/Discord/Guild.pm6
+++ b/lib/API/Discord/Guild.pm6
@@ -96,8 +96,7 @@ has @.presences;
 
 method assign-role($user, *@role-ids) {
     start {
-        my $e = endpoint-for( self, 'get-member', user-id => $user.id ) ;
-        my $member = await (await $.api.rest.get($e)).body;
+        my $member = self.get-member($user);
 
         $member<roles>.append: @role-ids;
 


### PR DESCRIPTION
Allows the `assign-role` method to make use of the new `get-member` method.