### PR TITLE
Update rest-host parameter to new URL

### DIFF
--- a/lib/API/Discord.rakumod
+++ b/lib/API/Discord.rakumod
@@ -145,7 +145,7 @@ has Int $.version = 6;
 #| Host to which to connect. Can be overridden for testing e.g.
 has Str $.ws-host = 'gateway.discord.gg';
 #| Host for REST requests
-has Str $.rest-host = 'discordapp.com';
+has Str $.rest-host = 'discord.com';
 #| Host for CDN URLs. This is gonna change eventually.
 has Str $.cdn-url = 'https://cdn.discordapp.com';
 #| Bot token or whatever, used for auth.


### PR DESCRIPTION
Eventually `discordapp.com` will be deprecated since Discord now own the `discord.com` domain. This PR does not touch the CDN domain parameter however, as this will remain at `cdn.discordapp.com` for the foreseeable future due to technical reasons on Discord's part.